### PR TITLE
mffs instruction should load to floating-point register.

### DIFF
--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -1248,7 +1248,7 @@ bool Recompiler::Recompile(
         break;
 
     case PPC_INST_MFFS:
-        println("\t{}.u64 = ctx.fpscr.loadFromHost();", r(insn.operands[0]));
+        println("\t{}.u64 = ctx.fpscr.loadFromHost();", f(insn.operands[0]));
         break;
 
     case PPC_INST_MFLR:


### PR DESCRIPTION
https://www.ibm.com/docs/en/aix/7.2.0?topic=set-mffs-move-from-fpscr-instruction

`mffs` loads to a floating-point register, as seen in the following pattern in Sonic 06:
```
	// mffs f0
	ctx.f0.u64 = ctx.fpscr.loadFromHost();
	// stfd f0,-8(r1)
	ctx.fpscr.disableFlushMode();
	PPC_STORE_U64(ctx.r1.u32 + -8, ctx.f0.u64);
        ....
	// lfd f0,-8(r1)
	ctx.f0.u64 = PPC_LOAD_U64(ctx.r1.u32 + -8);
	// mtfsf 255,f0
	ctx.fpscr.storeFromGuest(ctx.f0.u32);
```

Fixes some animations getting stuck.